### PR TITLE
Update astropy to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-astropy>=4.2
+astropy>=5.0
 matplotlib
 requests
 scipy


### PR DESCRIPTION
Bumping astropy to 5.0 for AAS239 for binder builds.